### PR TITLE
Added support for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Dockerfile for Syncthing Exporter
 FROM golang:1.14
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.14
+
+WORKDIR /app
+
+ENV WEB_LISTEN_PORT="9112"
+ENV WEB_LISTEN_ADDRESS=":${PORT}"
+ENV WEB_METRIC_PATH="/metrics"
+ENV ST_URI="http://127.0.0.1:8384"
+ENV ST_TOKEN="123"
+ENV ST_TIMEOUT="5s"
+
+RUN git clone https://github.com/adenau/syncthing_exporter.git
+
+WORKDIR /app/syncthing_exporter
+
+RUN go build .
+
+CMD ./syncthing_exporter
+EXPOSE ${PORT}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Syncthing exporter
 
-NEW to this Branch : Docker support
+NEW to this FORK : Docker support
 
 ### Build and run exporter
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Syncthing exporter
 
-NEW to this FORK : Docker support
-
 ### Build and run exporter
 
 Clone current repository and 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Syncthing exporter
 
+NEW to this Branch : Docker support
+
 ### Build and run exporter
 
 Clone current repository and 
@@ -48,6 +50,26 @@ For data obtaining is using two endpoints:
 Example of grafana dashboard:
 
 ![screenshot-1.png](./examples/grafana/screenshot-1.png)
+
+## Docker Support
+
+The following environment variables are supported
+
+Env Variable            | Default               | Description
+------------------------|-----------------------|--------------------------
+ENV WEB_LISTEN_PORT=    | "9112"                | Port to expose telemetry 
+ENV WEB_LISTEN_ADDRESS= | ":${PORT}"            | Address & port to expose telemetry
+ENV WEB_METRIC_PATH     | "/metrics"            | HTTP Path under which to expose telemetry
+ENV ST_URI=             | http://127.0.0.1:8384 | HTTP API address of Syncthing node
+ENV ST_TOKEN            | "123"                 | !Change this! Token for authentification Syncthing HTTP API
+ENV ST_TIMEOUT          | "5s"                  | Timeout for trying to get stats from Syncthing 
+
+To run, simply
+
+    docker run adenau/syncthing-exporter
+
+
+
 
 
 ## Communal effort


### PR DESCRIPTION
I've found that its pretty useful to run Prometheus exporters as Docker images. As such, I built a Dockerfile to determine how the image need to be created. 

The image can be compiled with
`docker build -t syncthing-exporter .`

A ready to use version of the image is available at : https://hub.docker.com/r/adenau/syncthing-exporter

The image was tested with the current version of syncthings ( v1.12.0, Linux (64 bit) ) and deployed in both Docker 19 and Docker 20.