### PR TITLE
Fix crash if lastConnectionDurationS is missing and check syncthing uri scheme at start

### DIFF
--- a/collector/rest_stats_device.go
+++ b/collector/rest_stats_device.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"time"
@@ -154,10 +155,17 @@ func (c *StatsDeviceResponse) Collect(ch chan<- prometheus.Metric) {
 
 	for deviceID, deviceData := range statsDeviceResponse {
 		deviceDataAssertion := deviceData.(map[string]interface{})
+		var lastConnectionDurationSMaybeNull = deviceDataAssertion["lastConnectionDurationS"]
+		var lastConnectionDurationS float64
+		if lastConnectionDurationSMaybeNull != nil {
+			lastConnectionDurationS = lastConnectionDurationSMaybeNull.(float64)
+		} else {
+			lastConnectionDurationS = math.NaN()
+		}
 		ch <- prometheus.MustNewConstMetric(
 			c.numericalMetrics["last_connection_duration"].Desc,
 			c.numericalMetrics["last_connection_duration"].Type,
-			c.numericalMetrics["last_connection_duration"].Value(deviceDataAssertion["lastConnectionDurationS"].(float64)),
+			c.numericalMetrics["last_connection_duration"].Value(lastConnectionDurationS),
 			deviceID,
 		)
 		thetime, err := time.Parse(time.RFC3339, deviceDataAssertion["lastSeen"].(string))

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -66,6 +67,14 @@ func main() {
 	if err != nil {
 		_ = level.Error(logger).Log(
 			"msg", "failed to parse syncthingURI",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	if stURL.Scheme != "http" && stURL.Scheme != "https" {
+		_ = level.Error(logger).Log(
+			"msg", fmt.Sprintf("The scheme %s is unsupported, the only supported schemes for syncthingURI are http and https", stURL.Scheme),
 			"err", err,
 		)
 		os.Exit(1)


### PR DESCRIPTION
Hello,
I discovered the following issue while using this exporter, the lastConnectionDurationS is missing in the output of the syncthing rest api /rest/stats/device.
I have implemented a null check, when the lastConnectionDurationS is nil it will be listed as NaN.

I have also implemented a scheme check at the start-up, to prevent the exporter from running with an invalid syncthing uri.
